### PR TITLE
Adding Test Cases for Calibration Classifier

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ torch>=1.6.0
 gpytorch>=1.3.0
 botorch>=0.3.2
 tqdm==4.42.0
-tensorflow
+tensorflow<=2.6
 tensorflow-hub
 gitpython==2.1.15
 umap-learn==0.3.10

--- a/tests/test_ClassificationCalibration.py
+++ b/tests/test_ClassificationCalibration.py
@@ -1,20 +1,14 @@
-import os
-import unittest
-from unittest import TestCase
-
-from tests.test_utils import create_train_test_prod_split, split
-from uq360.algorithms.classification_calibration import ClassificationCalibration
-import numpy as np
-import pandas as pd
-import tensorflow as tf
 import logging
+
 from sklearn.metrics import brier_score_loss
 from sklearn.utils._testing import (
-    assert_array_almost_equal,
-    assert_almost_equal,
     assert_array_equal,
-    ignore_warnings,
 )
+import tensorflow as tf
+from tests.test_utils import create_train_test_prod_split, split
+import unittest
+from unittest import TestCase
+from uq360.algorithms.classification_calibration import ClassificationCalibration
 tf.get_logger().setLevel(logging.ERROR)
 
 
@@ -46,9 +40,6 @@ class TestCalibratedClassifier(TestCase):
             calib_model_probs.fit(self.model.predict_proba(self.x_test), self.y_test)
             res_probs = calib_model_probs.predict(self.model.predict_proba(self.x_prod))
             # Compare results with uncalibrated classifier
-            print("Unaclibrate ",y_proba.shape)
-            print("calibrated ",res_probs.y_prob.shape)
-
             assert_array_equal(y_pred, res_probs.y_pred)
             assert brier_score_loss(self.y_prod, y_proba[:,0]) >= brier_score_loss(
                 self.y_prod, res_probs.y_prob[:,0])
@@ -63,7 +54,7 @@ class TestCalibratedClassifier(TestCase):
             calib_model_feat.fit(self.x_test, self.y_test)
             res_feat = calib_model_feat.predict(self.x_prod)
 
-
+            # Compare results with uncalibrated classifier
             assert_array_equal(y_pred, res_feat.y_pred)
             assert brier_score_loss(self.y_prod, y_proba[:,0]) >= brier_score_loss(
                 self.y_prod, res_feat.y_prob[:,0])
@@ -81,7 +72,7 @@ class TestCalibratedClassifier(TestCase):
         returns pre-trained model object
         """
         from sklearn.neural_network import MLPClassifier
-        model = MLPClassifier()
+        model = MLPClassifier(random_state = 42)
         model.fit(x, y)
         return model
 

--- a/tests/test_ClassificationCalibration.py
+++ b/tests/test_ClassificationCalibration.py
@@ -4,12 +4,10 @@ from sklearn.metrics import brier_score_loss
 from sklearn.utils._testing import (
     assert_array_equal,
 )
-import tensorflow as tf
 from tests.test_utils import create_train_test_prod_split, split
 import unittest
 from unittest import TestCase
 from uq360.algorithms.classification_calibration import ClassificationCalibration
-tf.get_logger().setLevel(logging.ERROR)
 
 
 class TestCalibratedClassifier(TestCase):
@@ -79,3 +77,4 @@ class TestCalibratedClassifier(TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+    

--- a/tests/test_ClassificationCalibration.py
+++ b/tests/test_ClassificationCalibration.py
@@ -1,0 +1,73 @@
+import os
+import unittest
+from unittest import TestCase
+
+from tests.test_utils import create_train_test_prod_split, split
+from uq360.algorithms.classification_calibration import ClassificationCalibration
+import numpy as np
+import pandas as pd
+import tensorflow as tf
+import logging
+
+tf.get_logger().setLevel(logging.ERROR)
+
+
+class TestCalibratedClassifier(TestCase):
+
+    def setUp(self):
+        self.num_classes = 4
+        X, y = self._generate_mock_data(n_samples  = 10000,
+             n_classes= self.num_classes, n_features = 8) 
+    
+        x_train, y_train, x_test, y_test, x_prod, y_prod = create_train_test_prod_split(X, y)
+
+        self.x_test = x_test
+        self.y_test = y_test
+        self.x_prod = x_prod
+        self.y_prod = y_prod
+        self.model = self._train_model(x_train, y_train)
+
+    def test_calibrated_classifier(self):
+        
+        # Check if calibrated classifier runs with probs method
+        calib_model_probs = ClassificationCalibration(self.num_classes, 
+                fit_mode = 'probs')
+
+        calib_model_probs.fit(self.x_test, self.y_test)
+        res_probs = calib_model_probs.predict(self.x_prod)
+
+        # check if features fit_mode runs model run
+
+        ## Gives an error right now
+        calib_model_feat = ClassificationCalibration(self.num_classes, fit_mode = 'features',
+                base_model_prediction_func = self._wrapper_for_fit)
+
+        calib_model_feat.fit(self.x_test, self.y_test)
+        res_feat = calib_model_feat.predict(self.x_prod)
+
+
+
+
+
+    def _generate_mock_data(self, n_samples, n_classes, n_features):
+        from sklearn.datasets import make_classification
+        return make_classification(n_samples=n_samples, n_features=n_features, n_classes=n_classes,
+                                   n_informative=n_features, n_redundant=0, random_state=42, class_sep=10)
+
+
+    def _train_model(self, x, y):
+        """
+        returns pre-trained model object
+        """
+        from sklearn.neural_network import MLPClassifier
+        model = MLPClassifier()
+        model.fit(x, y)
+        return model
+
+    def _wrapper_for_fit(self):
+        return self.model.predict_proba
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_ClassificationCalibration.py
+++ b/tests/test_ClassificationCalibration.py
@@ -32,15 +32,15 @@ class TestCalibratedClassifier(TestCase):
         # Check if calibrated classifier runs with probs method
         calib_model_probs = ClassificationCalibration(self.num_classes, 
                 fit_mode = 'probs')
-
-        calib_model_probs.fit(self.x_test, self.y_test)
-        res_probs = calib_model_probs.predict(self.x_prod)
+        # Fitting probs mode using probability scores
+        calib_model_probs.fit(self.model.predict_proba(self.x_test), self.y_test)
+        res_probs = calib_model_probs.predict(self.model.predict_proba(self.x_test))
 
         # check if features fit_mode runs model run
 
         ## Gives an error right now
         calib_model_feat = ClassificationCalibration(self.num_classes, fit_mode = 'features',
-                base_model_prediction_func = self._wrapper_for_fit)
+                base_model_prediction_func = self.model.predict_proba)
 
         calib_model_feat.fit(self.x_test, self.y_test)
         res_feat = calib_model_feat.predict(self.x_prod)
@@ -63,10 +63,6 @@ class TestCalibratedClassifier(TestCase):
         model = MLPClassifier()
         model.fit(x, y)
         return model
-
-    def _wrapper_for_fit(self):
-        return self.model.predict_proba
-
 
 
 if __name__ == '__main__':

--- a/tests/test_ClassificationCalibration.py
+++ b/tests/test_ClassificationCalibration.py
@@ -8,14 +8,20 @@ import numpy as np
 import pandas as pd
 import tensorflow as tf
 import logging
-
+from sklearn.metrics import brier_score_loss
+from sklearn.utils._testing import (
+    assert_array_almost_equal,
+    assert_almost_equal,
+    assert_array_equal,
+    ignore_warnings,
+)
 tf.get_logger().setLevel(logging.ERROR)
 
 
 class TestCalibratedClassifier(TestCase):
 
     def setUp(self):
-        self.num_classes = 4
+        self.num_classes = 2
         X, y = self._generate_mock_data(n_samples  = 10000,
              n_classes= self.num_classes, n_features = 8) 
     
@@ -27,25 +33,40 @@ class TestCalibratedClassifier(TestCase):
         self.y_prod = y_prod
         self.model = self._train_model(x_train, y_train)
 
-    def test_calibrated_classifier(self):
-        
-        # Check if calibrated classifier runs with probs method
-        calib_model_probs = ClassificationCalibration(self.num_classes, 
-                fit_mode = 'probs')
-        # Fitting probs mode using probability scores
-        calib_model_probs.fit(self.model.predict_proba(self.x_test), self.y_test)
-        res_probs = calib_model_probs.predict(self.model.predict_proba(self.x_test))
-
-        # check if features fit_mode runs model run
-
-        ## Gives an error right now
-        calib_model_feat = ClassificationCalibration(self.num_classes, fit_mode = 'features',
-                base_model_prediction_func = self.model.predict_proba)
-
-        calib_model_feat.fit(self.x_test, self.y_test)
-        res_feat = calib_model_feat.predict(self.x_prod)
 
 
+    def test_calibrated_classifier(self):    
+        # Predictions for uncalibrated classifier
+        y_pred = self.model.predict(self.x_prod)
+        y_proba = self.model.predict_proba(self.x_prod)
+        for method in ["isotonic", "sigmoid"]:
+            # Estimator runs for fit_mode = 'probs'
+            calib_model_probs = ClassificationCalibration(self.num_classes, 
+                    fit_mode = 'probs', method = method)
+            calib_model_probs.fit(self.model.predict_proba(self.x_test), self.y_test)
+            res_probs = calib_model_probs.predict(self.model.predict_proba(self.x_prod))
+            # Compare results with uncalibrated classifier
+            print("Unaclibrate ",y_proba.shape)
+            print("calibrated ",res_probs.y_prob.shape)
+
+            assert_array_equal(y_pred, res_probs.y_pred)
+            assert brier_score_loss(self.y_prod, y_proba[:,0]) >= brier_score_loss(
+                self.y_prod, res_probs.y_prob[:,0])
+
+            # Estimator runs for fit_mode = 'features'
+            calib_model_feat = ClassificationCalibration(self.num_classes, fit_mode = 'features',
+                    base_model_prediction_func = self.model.predict_proba,
+                    method = method)
+
+       
+
+            calib_model_feat.fit(self.x_test, self.y_test)
+            res_feat = calib_model_feat.predict(self.x_prod)
+
+
+            assert_array_equal(y_pred, res_feat.y_pred)
+            assert brier_score_loss(self.y_prod, y_proba[:,0]) >= brier_score_loss(
+                self.y_prod, res_feat.y_prob[:,0])
 
 
 


### PR DESCRIPTION
The following PR added test cases for classification_calibration.py 
The test cases cover the following use cases
1. The classifier runs in all fit_modes and method types
2. Adding that there is improvement in Brier score after calibration 
and the predicted class is unchanged