### PR TITLE
Assert inputs are the right type

### DIFF
--- a/uq360/algorithms/variational_bayesian_neural_networks/bnn.py
+++ b/uq360/algorithms/variational_bayesian_neural_networks/bnn.py
@@ -64,6 +64,9 @@ class BnnRegression(BuiltinUQ):
             self
 
         """
+        assert type(X) == torch.Tensor, f"Expected X type torch.Tensor but found {type(X)}"
+        assert type(y) == torch.Tensor, f"Expected X type torch.Tensor but found {type(y)}"
+
         torch.manual_seed(1234)
         optimizer = torch.optim.Adam(self.net.parameters(), lr=self.config['step_size'])
         neg_elbo = torch.zeros([self.config['num_epochs'], 1])


### PR DESCRIPTION
Assert the inputs are the correct type. There is no way for the end-user to know the right input type only by reading the documentation; therefore, code should speak by itself, asserting the correct type.